### PR TITLE
Add .NET 6 target framework

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,38 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+
+# Scripts
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.sh       text eol=lf
+# These are explicitly windows files and should use crlf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+*.ps1      text eol=crlf
+
+# CSharp
+*.cs       text diff=csharp
+*.cshtml   text diff=html
+*.csx      text diff=csharp
+*.sln      text eol=crlf merge=union
+*.csproj   text merge=union
+
+# Serialisation
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Archives
+*.7z       binary
+*.gz       binary
+*.tar      binary
+*.tgz      binary
+*.zip      binary
+
+# Text files where line endings should be preserved
+*.patch    -text

--- a/TSQLLint.Common.Tests/TSQLLint.Common.Tests.csproj
+++ b/TSQLLint.Common.Tests/TSQLLint.Common.Tests.csproj
@@ -1,16 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <AssemblyName>TSQLLint.Common.Tests</AssemblyName>
     <RootNamespace>TSQLLint.Common.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit.Console" Version="3.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit.Console" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TSQLLint.Common.sln
+++ b/TSQLLint.Common.sln
@@ -10,7 +10,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{16EB0E25-8B51-4117-8E9E-097E88FC8FBC}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
-		appveyor.yml = appveyor.yml
 		TSQLLint.Common.nuspec = TSQLLint.Common.nuspec
 	EndProjectSection
 EndProject

--- a/TSQLLint.Common.sln
+++ b/TSQLLint.Common.sln
@@ -1,13 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.15
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32126.317
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TSQLLint.Common", "TSQLLint.Common\TSQLLint.Common.csproj", "{BA93055D-76AE-4C24-AEA6-BBB90EDC4655}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TSQLLint.Common.Tests", "TSQLLint.Common.Tests\TSQLLint.Common.Tests.csproj", "{E0C267EF-75BE-4DDF-9AF3-1EFE2226E431}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolitionItems", "SolitionItems", "{16EB0E25-8B51-4117-8E9E-097E88FC8FBC}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{16EB0E25-8B51-4117-8E9E-097E88FC8FBC}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml

--- a/TSQLLint.Common/TSQLLint.Common.csproj
+++ b/TSQLLint.Common/TSQLLint.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
     <PackageId>TSQLLint.Common</PackageId>
     <Authors>Nathan Boyd</Authors>
     <Company>TSQLLint</Company>
@@ -8,7 +8,7 @@
     <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
     <Description>Common interfaces for TSQLLint Console, Lib, and Plugins</Description>
     <PackageTags>linting;mssql;tsql</PackageTags>
-    <Copyright>Copyright 2017</Copyright>
+    <Copyright>Copyright 2022</Copyright>
     <Version Condition=" '$(ProjectAVersion)' != '' ">$(ProjectAVersion)</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is a first prerequisite to be able to target .NET 6 cleanly in the main TSQLLint project. This simply modernizes the project, an adding another target framework.

The first upgrade step was by using the dotnet tool called "upgrade-assistant", to find issues and all.

I cannot really add tests, since there wasn't any tests originally here. Also I can't target the branch "dev", since it doesn't exist, so I'm targeting "main".

One thing that will need some checking, is that the build/packaging scripts use a docker image, with version 0.0.2, but the repo containing this Dockerfile isn't updated to represent what is in the image. So I needed to create an Dockerfile with the first line "`FROM nathanboyd/github_cli:0.0.2`" and installing dotnet 6 support. If I would have the original files, I would've explained the changes required more in detail.

Relates to tsqllint/tsqllint#273