### PR TITLE
Added `RULE_SEVERITY` as a read-only property for `ISqlLintRule` interface.

### DIFF
--- a/TSQLLint.Common/Interfaces/ISqlRule.cs
+++ b/TSQLLint.Common/Interfaces/ISqlRule.cs
@@ -6,6 +6,8 @@ namespace TSQLLint.Common
     {
         string RULE_NAME { get; }
 
+        RuleViolationSeverity RULE_SEVERITY { get; }
+
         public void FixViolation(List<string> fileLines, IRuleViolation ruleViolation, FileLineActions actions);
     }
 }


### PR DESCRIPTION
- Added `RULE_SEVERITY` as a read-only property for `ISqlLintRule` interface.
- This is for allowing plugins to pass in rules and have a default `RuleViolationSeverity` other than `RuleViolationSeverity.Off`