### PR TITLE
Added rules support for plugins by default

### DIFF
--- a/TSQLLint.Common.Tests/UnitTests/TestPlugin.cs
+++ b/TSQLLint.Common.Tests/UnitTests/TestPlugin.cs
@@ -1,13 +1,21 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace TSQLLint.Common.Tests
 {
     public class TestPlugin : IPlugin
     {
-
         public void PerformAction(IPluginContext context, IReporter reporter)
         {
             throw new NotImplementedException();
         }
+    }
+
+    // TODO: Remove this class when removing IPluginWithRules
+    public class TestPluginWithRules : IPluginWithRules
+    {
+        public void PerformAction(IPluginContext context, IReporter reporter) => throw new NotImplementedException();
+
+        public Dictionary<string, ISqlLintRule> Rules => throw new NotImplementedException();
     }
 }

--- a/TSQLLint.Common.Tests/UnitTests/Types/PluginTests.cs
+++ b/TSQLLint.Common.Tests/UnitTests/Types/PluginTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 
 namespace TSQLLint.Common.Tests
 {
@@ -8,8 +9,18 @@ namespace TSQLLint.Common.Tests
         [Test]
         public void TestPlugin()
         {
-            var testPlugin = new TestPlugin();
+            IPlugin testPlugin = new TestPlugin();
             Assert.Throws<NotImplementedException>(() => { testPlugin.PerformAction(null, null); });
+            Assert.That(testPlugin.GetRules(), Is.Empty.And.InstanceOf<IDictionary<string, ISqlLintRule>>());
+        }
+
+        // TODO: Remove this test when removing IPluginWithRules
+        [Test]
+        public void TestPluginWithRulesAsIPlugin()
+        {
+            IPlugin testPluginWithRules = new TestPluginWithRules();
+            Assert.Throws<NotImplementedException>(() => { testPluginWithRules.PerformAction(null, null); });
+            Assert.Throws<NotImplementedException>(() => { _ = testPluginWithRules.GetRules(); });
         }
     }
 }

--- a/TSQLLint.Common/Interfaces/IPlugin.cs
+++ b/TSQLLint.Common/Interfaces/IPlugin.cs
@@ -1,7 +1,11 @@
-﻿namespace TSQLLint.Common
+﻿using System.Collections.Generic;
+
+namespace TSQLLint.Common
 {
     public interface IPlugin
     {
         void PerformAction(IPluginContext context, IReporter reporter);
+
+        IDictionary<string, ISqlLintRule> GetRules() => new Dictionary<string, ISqlLintRule>();
     }
 }

--- a/TSQLLint.Common/Interfaces/IPluginWithRules.cs
+++ b/TSQLLint.Common/Interfaces/IPluginWithRules.cs
@@ -1,12 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace TSQLLint.Common
 {
+    [Obsolete("Use IPlugin and implement GetRules method instead of using the Rules property.")]
     public interface IPluginWithRules : IPlugin
     {
         /// <summary>
         /// Required if you
         /// </summary>
         Dictionary<string, ISqlLintRule> Rules { get; }
+
+        IDictionary<string, ISqlLintRule> IPlugin.GetRules() => Rules;
     }
 }


### PR DESCRIPTION
- Updated `IPlugin` to have method `GetRules` with default method.
- Added backwards compatibility when using `IPluginWithRules` and the new `IPlugin.GetRules` method.
- Deprecated `IPluginWithRules`.
- Implementing https://github.com/tsqllint/tsqllint_common/issues/11