### PR TITLE
Increase reliability of release creation

### DIFF
--- a/scripts/github_create_release.sh
+++ b/scripts/github_create_release.sh
@@ -36,7 +36,7 @@ info "Logging into GitHub CLI..."
 ls -lah "$ARTIFACTS_DIR"
 
 # Read the GitHub token from the file and login
-cat "$GITHUB_TOKEN_FILE" > .githubtoken
+echo "${GITHUB_TOKEN_FILE}" > .githubtoken
 gh auth login --with-token < .githubtoken
 rm .githubtoken
 


### PR DESCRIPTION
- Replace manual reading of GitHub token with environment variable in `scripts/github_create_release.sh`

[scripts/github_create_release.sh]
- Replace manual reading of GitHub token with environment variable