### PR TITLE
Fix violation position tracking in FileLineActions and harden FixHelpers

### DIFF
--- a/TSQLLint.Common.Tests/Helpers/FixHelpersTests.cs
+++ b/TSQLLint.Common.Tests/Helpers/FixHelpersTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.SqlServer.TransactSql.ScriptDom;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -37,6 +38,116 @@ namespace TSQLLint.Common.Tests.Helpers
             var lines = new[] { line }.ToList();
             var result = FixHelpers.GetIndent(lines, tsqlStatement);
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void FindViolatingNode_NoMatch_ReturnsDefaultWithoutThrowing()
+        {
+            var lines = new[] { "SELECT 1" }.ToList();
+            // A position that matches no fragment's start.
+            var violation = new TestRuleViolation(99, 99);
+
+            // getFragment dereferences its argument; before the fix this threw
+            // NullReferenceException because FirstOrDefault returned null.
+            var (fragment, node) = FixHelpers.FindViolatingNode<SelectStatement, QueryExpression>(
+                lines, violation, x => x.QueryExpression);
+
+            Assert.That(fragment, Is.Null);
+            Assert.That(node, Is.Null);
+        }
+
+        [Test]
+        public void FindViolatingNode_Match_ReturnsNodeAndFragment()
+        {
+            var lines = new[] { "SELECT 1" }.ToList();
+            // The SELECT statement's query expression starts at line 1, column 1.
+            var violation = new TestRuleViolation(1, 1);
+
+            var (fragment, node) = FixHelpers.FindViolatingNode<SelectStatement, QueryExpression>(
+                lines, violation, x => x.QueryExpression);
+
+            Assert.That(node, Is.Not.Null);
+            Assert.That(fragment, Is.SameAs(node.QueryExpression));
+        }
+
+        [Test]
+        public void FindNodes_ParsesSqlServer2022Syntax()
+        {
+            // A named WINDOW clause is valid T-SQL 2022 (TSql160); TSql150Parser
+            // rejects it as a syntax error, which previously aborted the fix.
+            var lines = new[] { "SELECT c, SUM(c) OVER w FROM t WINDOW w AS (ORDER BY c);" }.ToList();
+
+            var nodes = FixHelpers.FindNodes<SelectStatement>(lines);
+
+            Assert.That(nodes.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void FindNodes_InvalidSql_Throws()
+        {
+            var lines = new[] { "SELECT FROM WHERE ((" }.ToList();
+
+            Assert.Throws<Exception>(() => FixHelpers.FindNodes<SelectStatement>(lines));
+        }
+
+        [Test]
+        public void FindNodes_FromFragment_FindsDescendants()
+        {
+            var lines = new[] { "SELECT a, b FROM t" }.ToList();
+            var statement = FixHelpers.FindNodes<SelectStatement>(lines).Single();
+
+            // The fragment overload walks the already-parsed subtree.
+            var columns = FixHelpers.FindNodes<ColumnReferenceExpression>(statement);
+
+            Assert.That(columns.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void FindNodes_FromFragment_HonoursWherePredicate()
+        {
+            var lines = new[] { "SELECT a, b FROM t" }.ToList();
+            var statement = FixHelpers.FindNodes<SelectStatement>(lines).Single();
+
+            var columns = FixHelpers.FindNodes<ColumnReferenceExpression>(
+                statement,
+                c => FixHelpers.GetString(c) == "b");
+
+            Assert.That(columns.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void FindViolatingNode_SingleType_ReturnsMatchingNode()
+        {
+            var lines = new[] { "SELECT 1" }.ToList();
+            // The SELECT statement starts at line 1, column 1.
+            var violation = new TestRuleViolation(1, 1);
+
+            var node = FixHelpers.FindViolatingNode<SelectStatement>(lines, violation);
+
+            Assert.That(node, Is.Not.Null);
+        }
+
+        [Test]
+        public void FindViolatingNode_SingleType_NoMatch_ReturnsNull()
+        {
+            var lines = new[] { "SELECT 1" }.ToList();
+            var violation = new TestRuleViolation(99, 99);
+
+            var node = FixHelpers.FindViolatingNode<SelectStatement>(lines, violation);
+
+            Assert.That(node, Is.Null);
+        }
+
+        [Test]
+        public void GetString_ReconstructsFragmentText()
+        {
+            var lines = new[] { "SELECT a, b FROM t" }.ToList();
+            var column = FixHelpers.FindNodes<ColumnReferenceExpression>(lines)
+                .Single(c => c.ScriptTokenStream[c.FirstTokenIndex].Text == "b");
+
+            var result = FixHelpers.GetString(column);
+
+            Assert.That(result, Is.EqualTo("b"));
         }
     }
 }

--- a/TSQLLint.Common.Tests/Helpers/FixLineActionsTests.cs
+++ b/TSQLLint.Common.Tests/Helpers/FixLineActionsTests.cs
@@ -140,7 +140,7 @@ namespace TSQLLint.Common.Tests.Helpers
             var column = Lines[2].IndexOf("line") + 1;
             Violations.Add(new TestRuleViolation(3, column));
 
-            Subject.RepaceInlineAt(2, 0, "THIS");
+            Subject.ReplaceInlineAt(2, 0, "THIS");
 
             Assert.AreEqual(1, Violations[0].Column);
             Assert.AreEqual(column, Violations[1].Column);
@@ -152,10 +152,41 @@ namespace TSQLLint.Common.Tests.Helpers
             var column = Lines[2].IndexOf("line") + 1;
             Violations.Add(new TestRuleViolation(3, column));
 
-            Subject.RepaceInlineAt(2, 0, "THIS", 5);
+            Subject.ReplaceInlineAt(2, 0, "THIS", 5);
 
             Assert.AreEqual(1, Violations[0].Column);
             Assert.AreEqual(column - 1, Violations[1].Column);
+        }
+
+        [Test]
+        public void ReplaceAtGrowing()
+        {
+            // "This is line 3": violation on the 'i' of "This" (0-based index 2 => Column 3).
+            Violations.Add(new TestRuleViolation(3, 3));
+
+            // Replace the 2 chars "Th" with 6 chars: net growth of +4.
+            Subject.ReplaceInlineAt(2, 0, "XXXXXX", 2);
+
+            // The default violation at Column 1 sits inside the replaced region and is not shifted.
+            Assert.That(Violations[0].Column, Is.EqualTo(1));
+            // The 'i' moves from Column 3 to Column 7; the buggy threshold left it at 3.
+            Assert.That(Violations[1].Column, Is.EqualTo(7));
+        }
+
+        [Test]
+        public void RepaceInlineAt_Obsolete_DelegatesToReplaceInlineAt()
+        {
+            var column = Lines[2].IndexOf("line") + 1;
+            Violations.Add(new TestRuleViolation(3, column));
+
+            // The misspelled method is obsolete but must still behave identically.
+#pragma warning disable CS0618 // Type or member is obsolete
+            Subject.RepaceInlineAt(2, 0, "THIS");
+#pragma warning restore CS0618
+
+            Assert.That(Lines[2], Is.EqualTo("THIS is line 3"));
+            Assert.That(Violations[0].Column, Is.EqualTo(1));
+            Assert.That(Violations[1].Column, Is.EqualTo(column));
         }
 
         [Test]

--- a/TSQLLint.Common.Tests/Helpers/FixLineActionsTests.cs
+++ b/TSQLLint.Common.Tests/Helpers/FixLineActionsTests.cs
@@ -84,9 +84,54 @@ namespace TSQLLint.Common.Tests.Helpers
         {
             var expected = Lines[0].Substring(4);
 
+            // Violation on the edited line, after the removal point: its column must shift left.
+            var onEditedLine = new TestRuleViolation(1, 9);
+            // Control on another line whose column equals the edited line number (1):
+            // it must NOT be touched by an edit to line 1.
+            var onOtherLine = new TestRuleViolation(3, 1);
+            Violations.Clear();
+            Violations.Add(onEditedLine);
+            Violations.Add(onOtherLine);
+
             Subject.RemoveInLine(0, 0, 4);
 
             Assert.AreEqual(expected, Lines[0]);
+            Assert.That(onEditedLine.Column, Is.EqualTo(5));
+            Assert.That(onOtherLine.Column, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void RemoveInLine_ViolationInsideRemovedSpan_ClampsToStart()
+        {
+            // Remove "This " (chars 0..4) from line 1. A violation at Column 3 ('i')
+            // points inside the removed span, so its character is gone; it must clamp
+            // to the start of the removal (Column 1), not go to a negative column.
+            var insideSpan = new TestRuleViolation(1, 3);
+            Violations.Clear();
+            Violations.Add(insideSpan);
+
+            Subject.RemoveInLine(0, 0, 5);
+
+            // Old code did 3 - 5 = -2; clamp keeps it at charIndex + 1 = 1.
+            Assert.That(insideSpan.Column, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void RemoveInLine_RemovalMidLine_ClampsAndShiftsAroundSpan()
+        {
+            // Line 1 = "Hi. This is line 1". Remove 5 chars starting at index 4 ("This ").
+            // Violation at Column 6 is inside the span -> clamp to charIndex + 1 = 5.
+            // Violation at Column 12 is after the span -> shift left by 5 to Column 7.
+            var insideSpan = new TestRuleViolation(1, 6);
+            var afterSpan = new TestRuleViolation(1, 12);
+            Violations.Clear();
+            Violations.Add(insideSpan);
+            Violations.Add(afterSpan);
+
+            Subject.RemoveInLine(0, 4, 5);
+
+            Assert.That(insideSpan.Column, Is.EqualTo(5));
+            Assert.That(afterSpan.Column, Is.EqualTo(7));
         }
 
         [Test]

--- a/TSQLLint.Common.Tests/Helpers/FixLineActionsTests.cs
+++ b/TSQLLint.Common.Tests/Helpers/FixLineActionsTests.cs
@@ -222,6 +222,19 @@ namespace TSQLLint.Common.Tests.Helpers
             Assert.AreEqual(1, Violations[0].Line);
         }
 
+        [Test]
+        public void UpdateLine()
+        {
+            var content = "Replacement content";
+
+            Subject.UpdateLine(2, content);
+
+            Assert.That(Lines[2], Is.EqualTo(content));
+            // UpdateLine replaces the whole line and does not touch violation positions.
+            Assert.That(Violations[0].Line, Is.EqualTo(3));
+            Assert.That(Violations[0].Column, Is.EqualTo(1));
+        }
+
         private void SetupDefaultLines()
         {
             Lines = new List<string>

--- a/TSQLLint.Common/Helpers/FileLineActions.cs
+++ b/TSQLLint.Common/Helpers/FileLineActions.cs
@@ -86,7 +86,13 @@ namespace TSQLLint.Common
             }
         }
 
+        [Obsolete("Use ReplaceInlineAt instead. This method is misspelled and will be removed in a future release.")]
         public void RepaceInlineAt(int lineIndex, int charIndex, string content, int? replaceLength = null)
+        {
+            ReplaceInlineAt(lineIndex, charIndex, content, replaceLength);
+        }
+
+        public void ReplaceInlineAt(int lineIndex, int charIndex, string content, int? replaceLength = null)
         {
             var line = FileLines[lineIndex];
             line = line.Remove(charIndex, replaceLength ?? content.Length);
@@ -97,7 +103,7 @@ namespace TSQLLint.Common
             {
                 var lengthDiff = content.Length - replaceLength;
                 foreach (var v in RuleViolations.Where(x => x.Line == lineIndex + 1
-                    && x.Column > charIndex + content.Length))
+                    && x.Column > charIndex + replaceLength.Value))
                 {
                     v.Column += lengthDiff.Value;
                 }

--- a/TSQLLint.Common/Helpers/FileLineActions.cs
+++ b/TSQLLint.Common/Helpers/FileLineActions.cs
@@ -66,10 +66,13 @@ namespace TSQLLint.Common
             line = line.Remove(charIndex, length);
             FileLines[lineIndex] = line;
 
-            foreach (var v in RuleViolations.Where(x => x.Column == lineIndex + 1
+            foreach (var v in RuleViolations.Where(x => x.Line == lineIndex + 1
                 && x.Column > charIndex))
             {
-                v.Column -= length;
+                // Violations after the removed span shift left by length; violations
+                // inside the span (their character was deleted) clamp to the start of
+                // the removal so the column can never become zero or negative.
+                v.Column = Math.Max(charIndex + 1, v.Column - length);
             }
         }
 

--- a/TSQLLint.Common/Helpers/FixHelpers.cs
+++ b/TSQLLint.Common/Helpers/FixHelpers.cs
@@ -21,6 +21,11 @@ namespace TSQLLint.Common
                        fragment?.StartColumn == ruleViolation.Column;
             });
 
+            if (node == null)
+            {
+                return default;
+            }
+
             return (getFragment(node), node);
         }
 
@@ -28,7 +33,7 @@ namespace TSQLLint.Common
              where T : TSqlFragment
         {
             using var rdr = new StringReader(string.Join("\n", fileLines));
-            var parser = new TSql150Parser(true, SqlEngineType.All);
+            var parser = new TSql160Parser(true, SqlEngineType.All);
             var tree = parser.Parse(rdr, out var errors);
 
             if (errors?.Any() == true)
@@ -37,7 +42,10 @@ namespace TSQLLint.Common
             }
 
             var checker = new FindViolatingNodeVisitor<T>(where);
-            tree.Accept(checker);
+
+            // Parse can return a null tree on severe errors even when the error
+            // collection is empty; the null-conditional skips Accept and returns no nodes.
+            tree?.Accept(checker);
 
             return checker.Nodes;
         }


### PR DESCRIPTION
## Summary

Three focused fixes to the fix-application helpers, each with test coverage:

- **Fix `RemoveInLine` violation column adjustment** — corrected a predicate that filtered on the wrong field (`Column` instead of `Line`) so edits no longer shift violations on unrelated lines, and added a clamp so a violation inside the removed span can't be pushed to a zero/negative column.
- **Add `ReplaceInlineAt` and fix growing-replacement column shift** — introduced the correctly-spelled method, marked the misspelled `RepaceInlineAt` `[Obsolete]` (delegating to the new name so existing callers keep working), and fixed the column-shift threshold so violations between the old and new end of a growing replacement are shifted correctly.
- **Harden `FixHelpers` node lookup** — `FindViolatingNode` now returns `default` when no node matches instead of dereferencing null; the parser was upgraded from `TSql150Parser` to `TSql160Parser` so valid SQL Server 2022 syntax (e.g. named `WINDOW` clauses) is no longer rejected; and the parse tree is null-guarded before it is visited.

## Testing

`dotnet test` — 32 passing.