### PR TITLE
Target net8.0 and net10.0; upgrade dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
   build:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:7.0
+      - image: mcr.microsoft.com/dotnet/sdk:10.0
     steps:
       - checkout
       - run:
@@ -12,7 +12,7 @@ jobs:
 
   build and notify:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:7.0
+      - image: mcr.microsoft.com/dotnet/sdk:10.0
     steps:
       - checkout
       - run:
@@ -41,7 +41,7 @@ jobs:
 
   package and push to nuget:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:7.0
+      - image: mcr.microsoft.com/dotnet/sdk:10.0
     steps:
       - checkout
       - run:

--- a/TSQLLint.Common.Tests/TSQLLint.Common.Tests.csproj
+++ b/TSQLLint.Common.Tests/TSQLLint.Common.Tests.csproj
@@ -8,10 +8,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0-preview-20220401-08" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit.Console" Version="3.15.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Console" Version="3.22.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TSQLLint.Common.Tests/TSQLLint.Common.Tests.csproj
+++ b/TSQLLint.Common.Tests/TSQLLint.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <AssemblyName>TSQLLint.Common.Tests</AssemblyName>
     <RootNamespace>TSQLLint.Common.Tests</RootNamespace>
   </PropertyGroup>

--- a/TSQLLint.Common/TSQLLint.Common.csproj
+++ b/TSQLLint.Common/TSQLLint.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net7.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<PackageId>TSQLLint.Common</PackageId>
 		<Authors>Nathan Boyd</Authors>
 		<Company>TSQLLint</Company>

--- a/TSQLLint.Common/TSQLLint.Common.csproj
+++ b/TSQLLint.Common/TSQLLint.Common.csproj
@@ -14,6 +14,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SqlServer.DacFx" Version="160.5400.1" />
+		<PackageReference Include="Microsoft.SqlServer.DacFx" Version="170.4.83" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Retargets the projects off the end-of-life net7.0 and refreshes NuGet dependencies.

- **Frameworks:** `net7.0` → `net8.0;net10.0` for both `TSQLLint.Common` and `TSQLLint.Common.Tests`. CircleCI SDK image bumped `7.0` → `10.0` so both targets build in CI.
- **Dependencies:**
  - Microsoft.SqlServer.DacFx `160.5400.1` → `170.4.83`
  - Microsoft.NET.Test.Sdk `17.2.0-preview` → `18.8.1`
  - NUnit `3.13.3` → `3.14.0`
  - NUnit.Console `3.15.0` → `3.22.0`
  - NUnit3TestAdapter `4.2.1` → `6.2.0`

## Testing

`dotnet test` across both target frameworks — 18 passing on net8.0 and 18 passing on net10.0.